### PR TITLE
api_keyのデフォルトを環境変数にする

### DIFF
--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -17,7 +17,7 @@ module ChatWork
 
   @api_base = 'https://api.chatwork.com/'
   @api_version = '/v1'
-  @api_key = ENV['CHATWORK_API_TOKEN']
+  @api_key = nil
 
   class << self
     def client
@@ -39,7 +39,7 @@ module ChatWork
     end
 
     def api_key
-      @api_key
+      @api_key || ENV['CHATWORK_API_TOKEN']
     end
   end
 end

--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -17,7 +17,7 @@ module ChatWork
 
   @api_base = 'https://api.chatwork.com/'
   @api_version = '/v1'
-  @api_key = nil
+  @api_key = ENV['CHATWORK_API_TOKEN']
 
   class << self
     def client

--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -21,7 +21,7 @@ module ChatWork
 
   class << self
     def client
-      @client ||= Client.new(@api_key, @api_base, @api_version)
+      @client ||= Client.new(api_key, api_base, api_version)
     end
 
     def api_base=(new_value)
@@ -40,6 +40,10 @@ module ChatWork
 
     def api_key
       @api_key || ENV['CHATWORK_API_TOKEN']
+    end
+
+    def api_version
+      @api_version
     end
   end
 end

--- a/spec/lib/chatwork_spec.rb
+++ b/spec/lib/chatwork_spec.rb
@@ -26,7 +26,16 @@ describe ChatWork do
   end
 
   describe '#api_key' do
-    subject { super().api_key }
-    it { should be_nil }
+    context 'when does not set env' do
+      subject { super().api_key }
+      it { should be_nil }
+    end
+
+    context 'when sets env' do
+      let(:test_token) { 'chatwork_test_token' }
+      before { ENV['CHATWORK_API_TOKEN'] = test_token }
+      subject { super().api_key }
+      it { is_expected.to eq test_token }
+    end
   end
 end


### PR DESCRIPTION
## issue
https://github.com/asonas/chatwork-ruby/issues/11

## 実装内容
* api_keyのgetterにて@api_keyがなかった場合に環境変数`CHATWORK_API_TOKEN `を参照する
* `Client.new(@api_key, @api_base, @api_version)`の部分を各getterから呼び出す`Client.new(api_key, api_base, api_version)`にした
* テストコード

今回はClient.newの際の引数をインスタンス変数からgetterに変更しました。
この部分は好みの問題でもあると思いますので、ご指摘いただけますと幸いです