### PR TITLE
api v2 release

### DIFF
--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -16,7 +16,7 @@ module ChatWork
   autoload(:Contacts, 'chatwork/contacts')
 
   @api_base = 'https://api.chatwork.com/'
-  @api_version = '/v1'
+  @api_version = '/v2'
   @api_key = nil
 
   class << self


### PR DESCRIPTION
2017/1/26 chatwork api v2 release :tada:
http://help.chatwork.com/hc/ja/articles/115000019401

v1 will not be usable in May.
This PR will switch to v2

## log
```rb
[1] pry(main)> ChatWork.api_version
=> "/v2"
[2] pry(main)> ChatWork::Message.create(room_id: 202202202, body: "Hello, ChatWork!")
=> {"message_id"=>"17381455111"}
```