### PR TITLE
Relax faraday dependency for faraday v0.11.0

### DIFF
--- a/chatwork.gemspec
+++ b/chatwork.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.9.0"
+  spec.add_dependency "faraday", "~> 0.9"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I want to use latest faraday(v0.11.0), but `chatwork` gem is locked by legacy version 

# Example
Gemfile

```ruby
source "https://rubygems.org"

gem "chatwork", "0.4.0"
gem "faraday", "0.11.0"
```

```bash
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "faraday":
  In Gemfile:
    faraday (= 0.11.0)

    chatwork (= 0.4.0) was resolved to 0.4.0, which depends on
      faraday (~> 0.9.0)
```
