### PR TITLE
Support ChatWork OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Or install it yourself as:
 
 ## Usage
 
+### Case 1. with API Key
+
 ``` ruby
 require "chatwork"
 
@@ -36,6 +38,54 @@ ChatWork::Message.create(room_id: 1234, body: "Hello, ChatWork!")
 $ CHATWORK_API_TOKEN=xxx ruby send_message.rb
 ```
 
+### Case 2. with OAuth access token
+``` ruby
+require "chatwork"
+
+# Create message
+ChatWork.access_token = "XXX"
+ChatWork::Message.create(room_id: 1234, body: "Hello, ChatWork!")
+```
+
+or
+
+``` sh
+$ cat send_message_with_access_token.rb
+require "chatwork"
+
+ChatWork::Message.create(room_id: 1234, body: "Hello, ChatWork!")
+$ CHATWORK_ACCESS_TOKEN=xxx ruby send_message_with_access_token.rb
+```
+
+### Case 3. Refresh access token with refresh token
+``` ruby
+require "chatwork"
+
+ChatWork.client_id = "XXX"
+ChatWork.client_secret = "XXX"
+refresh_token = "XXX"
+token = ChatWork::Token.refresh_access_token(refresh_token)
+new_access_token = token["access_token"]
+
+# Create message
+ChatWork.access_token = new_access_token
+ChatWork::Message.create(room_id: 1234, body: "Hello, ChatWork!")
+```
+
+or
+
+``` sh
+$ cat refresh_access_token.rb
+require "chatwork"
+
+token = ChatWork::Token.refresh_access_token(ENV["REFRESH_TOKEN"])
+new_access_token = token["access_token"]
+
+# Create message
+ChatWork.access_token = new_access_token
+ChatWork::Message.create(room_id: 1234, body: "Hello, ChatWork!")
+$ CHATWORK_CLIENT_ID=xxx CHATWORK_CLIENT_SECRET=xxx REFRESH_TOKEN=xxx ruby refresh_access_token.rb
+```
 
 ## Contributing
 

--- a/chatwork.gemspec
+++ b/chatwork.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
 end

--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -1,6 +1,7 @@
 require "chatwork/version"
 
 module ChatWork
+  autoload(:BaseClient, 'chatwork/base_client')
   autoload(:Client, 'chatwork/client')
   autoload(:Operations, 'chatwork/operations')
   autoload(:ChatWorkError, 'chatwork/chatwork_error')

--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -3,6 +3,8 @@ require "chatwork/version"
 module ChatWork
   autoload(:BaseClient, 'chatwork/base_client')
   autoload(:Client, 'chatwork/client')
+  autoload(:OAuthClient, 'chatwork/oauth_client')
+  autoload(:Token, 'chatwork/token')
   autoload(:Operations, 'chatwork/operations')
   autoload(:ChatWorkError, 'chatwork/chatwork_error')
   autoload(:APIConnectionError, 'chatwork/chatwork_error')
@@ -17,18 +19,30 @@ module ChatWork
   autoload(:Contacts, 'chatwork/contacts')
 
   @api_base = 'https://api.chatwork.com/'
+  @oauth_api_base = 'https://oauth.chatwork.com/'
   @api_version = '/v2'
   @api_key = nil
   @access_token = nil
+  @client_id = nil
+  @client_secret = nil
 
   class << self
     def client
       @client ||= Client.new(api_key, access_token, api_base, api_version)
     end
 
+    def oauth_client
+      @oauth_client ||= OAuthClient.new(client_id, client_secret, oauth_api_base)
+    end
+
     def api_base=(new_value)
       @api_base = new_value
       @client = nil
+    end
+
+    def oauth_api_base=(new_value)
+      @oauth_api_base = new_value
+      @oauth_client = nil
     end
 
     def api_key=(new_value)
@@ -43,8 +57,22 @@ module ChatWork
       @client = nil
     end
 
+    def client_id=(new_value)
+      @client_id = new_value
+      @oauth_client = nil
+    end
+
+    def client_secret=(new_value)
+      @client_secret = new_value
+      @oauth_client = nil
+    end
+
     def api_base
       @api_base
+    end
+
+    def oauth_api_base
+      @oauth_api_base
     end
 
     def api_key
@@ -53,6 +81,14 @@ module ChatWork
 
     def access_token
       @access_token || ENV['CHATWORK_ACCESS_TOKEN']
+    end
+
+    def client_id
+      @client_id || ENV['CHATWORK_CLIENT_ID']
+    end
+
+    def client_secret
+      @client_secret || ENV['CHATWORK_CLIENT_SECRET']
     end
 
     def api_version

--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -18,10 +18,11 @@ module ChatWork
   @api_base = 'https://api.chatwork.com/'
   @api_version = '/v2'
   @api_key = nil
+  @access_token = nil
 
   class << self
     def client
-      @client ||= Client.new(api_key, api_base, api_version)
+      @client ||= Client.new(api_key, access_token, api_base, api_version)
     end
 
     def api_base=(new_value)
@@ -31,6 +32,13 @@ module ChatWork
 
     def api_key=(new_value)
       @api_key = new_value
+      @access_token = nil
+      @client = nil
+    end
+
+    def access_token=(new_value)
+      @api_key = nil
+      @access_token = new_value
       @client = nil
     end
 
@@ -40,6 +48,10 @@ module ChatWork
 
     def api_key
       @api_key || ENV['CHATWORK_API_TOKEN']
+    end
+
+    def access_token
+      @access_token || ENV['CHATWORK_ACCESS_TOKEN']
     end
 
     def api_version

--- a/lib/chatwork/base_client.rb
+++ b/lib/chatwork/base_client.rb
@@ -1,0 +1,48 @@
+require 'faraday'
+require 'json'
+
+module ChatWork
+  class BaseClient
+    def initialize(api_base, api_version, header)
+      default_header = {
+        'User-Agent' => "ChatWork#{api_version} RubyBinding/#{ChatWork::VERSION}"
+      }
+
+      default_header.merge!(header)
+
+      @conn = Faraday.new("#{api_base}#{api_version}", headers: default_header) do |builder|
+        builder.request :url_encoded
+        builder.adapter Faraday.default_adapter
+      end
+      @api_version = api_version
+    end
+
+    def handle_response(response)
+      case response.status
+      when 204
+        ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
+      when 200..299
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError => e
+          raise ChatWork::APIConnectionError.new("Response JSON is broken. #{e.message}: #{response.body}", e)
+        end
+      else
+        ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
+      end
+    end
+
+    Faraday::Connection::METHODS.each do |method|
+      define_method(method) do |url, *args, &block|
+        begin
+          response = @conn.__send__(method, @api_version + url, *args)
+        rescue Faraday::Error::ClientError => e
+          raise ChatWork::APIConnectionError.faraday_error(e)
+        end
+        payload = handle_response(response)
+        block.call(payload, response.headers) if block
+        payload
+      end
+    end
+  end
+end

--- a/lib/chatwork/client.rb
+++ b/lib/chatwork/client.rb
@@ -26,7 +26,7 @@ module ChatWork
     def handle_response(response)
       case response.status
       when 204
-        ChatWork::ChatWorkError.from_response(response.status, response.body)
+        ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
       when 200..299
         begin
           JSON.parse(response.body)
@@ -34,7 +34,7 @@ module ChatWork
           raise ChatWork::APIConnectionError.new("Response JSON is broken. #{e.message}: #{response.body}", e)
         end
       else
-        ChatWork::ChatWorkError.from_response(response.status, response.body)
+        ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
       end
     end
 

--- a/lib/chatwork/client.rb
+++ b/lib/chatwork/client.rb
@@ -3,11 +3,18 @@ require 'json'
 
 module ChatWork
   class Client
-    def initialize(api_key, api_base, api_version)
+    def initialize(api_key, access_token, api_base, api_version)
       default_header = {
-        'X-ChatWorkToken' => api_key,
         'User-Agent' => "ChatWork#{api_version} RubyBinding/#{ChatWork::VERSION}"
       }
+
+      if api_key
+        default_header['X-ChatWorkToken'] = api_key
+      elsif access_token
+        default_header['Authorization'] = "Bearer #{access_token}"
+      else
+        raise "Either api_key or access_token is required"
+      end
 
       @conn = Faraday.new("#{api_base}#{api_version}", headers: default_header) do |builder|
         builder.request :url_encoded

--- a/lib/chatwork/client.rb
+++ b/lib/chatwork/client.rb
@@ -1,53 +1,12 @@
-require 'faraday'
-require 'json'
-
 module ChatWork
-  class Client
+  class Client < BaseClient
     def initialize(api_key, access_token, api_base, api_version)
-      default_header = {
-        'User-Agent' => "ChatWork#{api_version} RubyBinding/#{ChatWork::VERSION}"
-      }
-
       if api_key
-        default_header['X-ChatWorkToken'] = api_key
+        super(api_base, api_version, {'X-ChatWorkToken' => api_key})
       elsif access_token
-        default_header['Authorization'] = "Bearer #{access_token}"
+        super(api_base, api_version, {'Authorization' => "Bearer #{access_token}"})
       else
         raise "Either api_key or access_token is required"
-      end
-
-      @conn = Faraday.new("#{api_base}#{api_version}", headers: default_header) do |builder|
-        builder.request :url_encoded
-        builder.adapter Faraday.default_adapter
-      end
-      @api_version = api_version
-    end
-
-    def handle_response(response)
-      case response.status
-      when 204
-        ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
-      when 200..299
-        begin
-          JSON.parse(response.body)
-        rescue JSON::ParserError => e
-          raise ChatWork::APIConnectionError.new("Response JSON is broken. #{e.message}: #{response.body}", e)
-        end
-      else
-        ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
-      end
-    end
-
-    Faraday::Connection::METHODS.each do |method|
-      define_method(method) do |url, *args, &block|
-        begin
-          response = @conn.__send__(method, @api_version + url, *args)
-        rescue Faraday::Error::ClientError => e
-          raise ChatWork::APIConnectionError.faraday_error(e)
-        end
-        payload = handle_response(response)
-        block.call(payload, response.headers) if block
-        payload
       end
     end
   end

--- a/lib/chatwork/oauth_client.rb
+++ b/lib/chatwork/oauth_client.rb
@@ -1,0 +1,10 @@
+require 'base64'
+
+module ChatWork
+  class OAuthClient < BaseClient
+    def initialize(client_id, client_secret, oauth_api_base)
+      signature = Base64.encode64("#{client_id}:#{client_secret}").gsub("\n", "")
+      super(oauth_api_base, "", {'Authorization' => "Basic #{signature}"})
+    end
+  end
+end

--- a/lib/chatwork/token.rb
+++ b/lib/chatwork/token.rb
@@ -1,0 +1,30 @@
+module ChatWork
+  class Token
+    # refresh access_token with refresh_token
+    #
+    # @param refresh_token [String]
+    # @param scope [Array<String>]
+    #
+    # @return [Hash]
+    # @example response
+    #   {
+    #     "access_token" => "new_access_token",
+    #     "token_type" => "Bearer",
+    #     "expires_in" => "1800",
+    #     "refresh_token" => "refresh_token",
+    #     "scope" => "users.all:read rooms.all:read_write contacts.all:read_write",
+    #   }
+    #   ["access_token", "token_type", "expires_in", "refresh_token", "scope"]
+    def self.refresh_access_token(refresh_token, scope = [])
+      params = {
+        grant_type:    "refresh_token",
+        refresh_token: refresh_token,
+      }
+      params[:scope] = scope.join(" ") unless scope.empty?
+
+      response = ChatWork.oauth_client.post("/token", params)
+      raise response if response.kind_of?(Exception)
+      response
+    end
+  end
+end

--- a/spec/lib/chatwork/chatwork_error_spec.rb
+++ b/spec/lib/chatwork/chatwork_error_spec.rb
@@ -1,0 +1,26 @@
+describe ChatWork::ChatWorkError do
+  describe '.from_response' do
+    subject { ChatWork::ChatWorkError.from_response(status, body, headers) }
+
+    context "with WWW-Authenticate header" do
+      let(:status) { 401 }
+
+      let(:body) do
+        <<-JSON
+          {"errors":["Invalid API Token"]}
+        JSON
+      end
+
+      let(:headers) do
+        {
+          'WWW-Authenticate' => 'Bearer error="invalid_token", error_description="The access token expired"'
+        }
+      end
+
+      it { should be_an_instance_of ChatWork::AuthenticateError }
+      its(:error) { should eq 'invalid_token' }
+      its(:error_description) { should eq 'The access token expired' }
+      its(:error_response) { should eq ['Invalid API Token'] }
+    end
+  end
+end

--- a/spec/lib/chatwork/client_spec.rb
+++ b/spec/lib/chatwork/client_spec.rb
@@ -1,0 +1,34 @@
+describe ChatWork::Client do
+  describe '#initialize' do
+    subject { ChatWork::Client.new(api_key, access_token, api_base, api_version) }
+
+    let(:api_key)      { nil }
+    let(:access_token) { nil }
+    let(:api_base)     { 'https://api.chatwork.com/' }
+    let(:api_version)  { '/v2' }
+
+    context 'with api_key' do
+      let(:api_key) { 'my_api_key' }
+
+      it 'client has X-ChatWorkToken header' do
+        connection = subject.instance_variable_get(:@conn)
+
+        expect(connection.headers['X-ChatWorkToken']).to eq "my_api_key"
+      end
+    end
+
+    context 'with access_token' do
+      let(:access_token) { 'my_access_token' }
+
+      it 'client has Authorization header' do
+        connection = subject.instance_variable_get(:@conn)
+
+        expect(connection.headers['Authorization']).to eq "Bearer my_access_token"
+      end
+    end
+
+    context 'without both api_key and access_token' do
+      it { expect { subject }.to raise_error 'Either api_key or access_token is required' }
+    end
+  end
+end

--- a/spec/lib/chatwork/oauth_client_spec.rb
+++ b/spec/lib/chatwork/oauth_client_spec.rb
@@ -1,0 +1,16 @@
+describe ChatWork::OAuthClient do
+  describe '#initialize' do
+    subject { ChatWork::OAuthClient.new(client_id, client_secret, api_base) }
+
+    let(:client_id)     { 'client_id' }
+    let(:client_secret) { 'client_secret' }
+    let(:api_base)      { 'https://token.chatwork.com/' }
+    let(:signature)     { 'Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=' }
+
+    it 'client has Authorization header' do
+      connection = subject.instance_variable_get(:@conn)
+
+      expect(connection.headers['Authorization']).to eq "Basic #{signature}"
+    end
+  end
+end

--- a/spec/lib/chatwork/token_spec.rb
+++ b/spec/lib/chatwork/token_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../shared_oauth_stubs.rb'
+
+describe ChatWork::Token do
+  include_context 'shared oauth stubs'
+
+  describe '.refresh_access_token' do
+    subject { ChatWork::Token.refresh_access_token(refresh_token, scope) }
+
+    let(:scope) { [] }
+
+    its(["access_token"])  { should eq "new_access_token" }
+    its(["token_type"])    { should eq "Bearer" }
+    its(["expires_in"])    { should eq "1800" }
+    its(["refresh_token"]) { should eq "refresh_token" }
+    its(["scope"])         { should eq "users.all:read rooms.all:read_write contacts.all:read_write" }
+  end
+end

--- a/spec/lib/chatwork_spec.rb
+++ b/spec/lib/chatwork_spec.rb
@@ -1,6 +1,11 @@
 describe ChatWork do
   describe '#client' do
     subject { super().client }
+
+    before do
+      allow(ChatWork).to receive(:api_key) { "aaaa" }
+    end
+
     it { should be_a(ChatWork::Client) }
   end
 
@@ -32,6 +37,20 @@ describe ChatWork do
       let(:test_token) { 'chatwork_test_token' }
       before { ENV['CHATWORK_API_TOKEN'] = test_token }
       subject { super().api_key }
+      it { is_expected.to eq test_token }
+    end
+  end
+
+  describe '#access_token' do
+    context 'when does not set env' do
+      subject { super().access_token }
+      it { should be_nil }
+    end
+
+    context 'when sets env' do
+      let(:test_token) { 'chatwork_test_token' }
+      before { ENV['CHATWORK_ACCESS_TOKEN'] = test_token }
+      subject { super().access_token }
       it { is_expected.to eq test_token }
     end
   end

--- a/spec/shared_oauth_stubs.rb
+++ b/spec/shared_oauth_stubs.rb
@@ -1,0 +1,49 @@
+require 'faraday'
+
+RSpec.shared_context "shared oauth stubs" do
+  let(:client_id) { 'client_id' }
+  let(:client_secret) { 'client_secret' }
+  let(:refresh_token) { 'refresh_token' }
+  let(:api_version) { ChatWork.api_version }
+  let(:oauth_api_base) { ChatWork.oauth_api_base }
+  let(:signature) { 'Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=' }
+
+  let(:test_adapter) {
+    token = {
+      access_token: 'new_access_token',
+      token_type: 'Bearer',
+      expires_in: '1800',
+      refresh_token: refresh_token,
+      scope: 'users.all:read rooms.all:read_write contacts.all:read_write'
+    }
+
+    Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post("/token") {
+        [200,
+        {"Content-Type" => "application/json"},
+        token.to_json ]
+      }
+    end
+  }
+
+  let(:faraday) {
+    default_header = {
+      'Authorization': "Basic #{signature}",
+      'User-Agent': "ChatWork#{api_version} RubyBinding/#{ChatWork::VERSION}"
+    }
+    Faraday.new(oauth_api_base, headers: default_header) do |builder|
+      builder.request :url_encoded
+      builder.adapter Faraday.default_adapter
+      builder.adapter :test, test_adapter
+    end
+  }
+
+  let(:oauth_client) {
+    allow(Faraday).to receive(:new).and_return(faraday)
+    ChatWork::OAuthClient.new(client_id, client_secret, oauth_api_base)
+  }
+
+  before(:each) do
+    allow(ChatWork).to receive(:oauth_client).and_return(oauth_client)
+  end
+end

--- a/spec/shared_stubs.rb
+++ b/spec/shared_stubs.rb
@@ -2,6 +2,7 @@ require 'faraday'
 
 RSpec.shared_context "shared stubs" do
   let(:api_key) { 'api_key' }
+  let(:access_token) { nil }
   let(:api_version) { ChatWork.api_version }
   let(:api_base) { ChatWork.api_base }
 
@@ -28,7 +29,7 @@ RSpec.shared_context "shared stubs" do
 
   let(:client) {
     allow(Faraday).to receive(:new).and_return(faraday)
-    client = ChatWork::Client.new(api_key, api_base, api_version)
+    client = ChatWork::Client.new(api_key, access_token, api_base, api_version)
     client
   }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,5 @@ $: << File.expand_path(File.join(*%w{.. .. lib}), __FILE__)
 
 require 'chatwork'
 
+require 'rspec/its'
 require_relative './shared_stubs'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,4 @@ require 'chatwork'
 
 require 'rspec/its'
 require_relative './shared_stubs'
+


### PR DESCRIPTION
# New Features
## Perform ChatWork API with access token
```ruby
require "chatwork"

ChatWork.access_token = "XXX"
ChatWork::Message.create(room_id: 1234, body: "Hello, ChatWork!")
```

## Refresh access token with refresh token
```ruby
require "chatwork"

ChatWork.client_id = "XXX"
ChatWork.client_secret = "XXX"
refresh_token = "XXX"
token = ChatWork::Token.refresh_access_token(refresh_token)
new_access_token = token["access_token"]

# Create message
ChatWork.access_token = new_access_token
ChatWork::Message.create(room_id: 1234, body: "Hello, ChatWork!")
```

# Specification 
See following

* http://blog-ja.chatwork.com/2017/11/api-openbeta.html (ja)
* http://developer.chatwork.com/ja/oauth.html (ja)
* http://download.chatwork.com/ChatWork_API_Documentation.pdf (en)

# Note
I think this PR conflicts with #20.
I will immediately resolve the conflict after you merge.