### PR TITLE
Add group to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,13 @@ source "https://rubygems.org"
 gemspec
 
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.3.0")
-  gem "backport_dig"
+  group :test do
+    gem "backport_dig", group: :development
+  end
 end
 
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.2")
-  gem "activesupport", "< 5.0.0"
+  group :test do
+    gem "activesupport", "< 5.0.0", group: :development
+  end
 end


### PR DESCRIPTION
`activesupport` and `backport_dig` are used only test code, but gemnasium regards that used in production code

https://gemnasium.com/github.com/asonas/chatwork-ruby

![image](https://user-images.githubusercontent.com/608755/34666207-82b48168-f4a6-11e7-971b-cfe29da3f166.png)
