### PR TITLE
raise error when status 4xx and 5xx

### DIFF
--- a/lib/chatwork/base_client.rb
+++ b/lib/chatwork/base_client.rb
@@ -29,7 +29,7 @@ module ChatWork
           raise ChatWork::APIConnectionError.new("Response JSON is broken. #{e.message}: #{response.body}", e)
         end
       else
-        ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
+        raise ChatWork::ChatWorkError.from_response(response.status, response.body, response.headers)
       end
     end
 

--- a/spec/lib/chatwork/me_spec.rb
+++ b/spec/lib/chatwork/me_spec.rb
@@ -7,5 +7,13 @@ describe ChatWork::Me do
     end
 
     it_behaves_like :a_chatwork_api, :get, "/me"
+
+    context "when unauthorized" do
+      before do
+        stub_chatwork_request(:get, "/me", "/me", 401)
+      end
+
+      it { expect { subject }.to raise_error(ChatWork::APIError, "Invalid API token") }
+    end
   end
 end


### PR DESCRIPTION
# Before
```ruby
[1] pry(main)> ChatWork::Me.get
#=> #<ChatWork::AuthenticateError: Bearer error="invalid_token", error_description="Invalid access token">
```

# After
```ruby
[1] pry(main)> ChatWork::Me.get
ChatWork::AuthenticateError: Bearer error="invalid_token", error_description="Invalid access token"
from /Users/sue445/dev/workspace/github.com/asonas/chatwork-ruby/lib/chatwork/base_client.rb:32:in `handle_response'
```