### PR TITLE
Returns `Hashie::Mash` instead of `Hash`

### DIFF
--- a/chatwork.gemspec
+++ b/chatwork.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 0.9"
+  spec.add_dependency "faraday_middleware"
+  spec.add_dependency "hashie"
 
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/chatwork/chatwork_error.rb
+++ b/lib/chatwork/chatwork_error.rb
@@ -1,22 +1,15 @@
-require "json"
 module ChatWork
   class ChatWorkError < StandardError
     def self.from_response(status, body, headers)
-      hash =
-        begin
-          JSON.parse(body)
-        rescue JSON::ParserError => e
-          return ChatWork::APIConnectionError.new("Response JSON is broken. #{e.message}: #{body}", e)
-        end
-      unless hash["errors"]
+      unless body["errors"]
         return APIConnectionError.new("Invalid response #{body}")
       end
 
       if headers.has_key?("WWW-Authenticate")
-        return AuthenticateError.new(headers["WWW-Authenticate"], status, hash["errors"])
+        return AuthenticateError.new(headers["WWW-Authenticate"], status, body["errors"])
       end
 
-      APIError.new(status, hash["errors"])
+      APIError.new(status, body["errors"])
     end
 
     attr_reader :status

--- a/lib/chatwork/contacts.rb
+++ b/lib/chatwork/contacts.rb
@@ -7,7 +7,7 @@ module ChatWork
     # @see http://developer.chatwork.com/ja/endpoint_contacts.html#GET-contacts
     # @see http://download.chatwork.com/ChatWork_API_Documentation.pdf
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [

--- a/lib/chatwork/file.rb
+++ b/lib/chatwork/file.rb
@@ -10,7 +10,7 @@ module ChatWork
     # @see http://developer.chatwork.com/ja/endpoint_rooms.html#GET-rooms-room_id-files
     # @see http://download.chatwork.com/ChatWork_API_Documentation.pdf
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [
@@ -41,7 +41,7 @@ module ChatWork
     # @param create_download_url [Boolean] whether or not to create a download link.
     #                                      If set to true, download like will be created for 30 seconds
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   {

--- a/lib/chatwork/incoming_request.rb
+++ b/lib/chatwork/incoming_request.rb
@@ -9,7 +9,7 @@ module ChatWork
     # @see http://developer.chatwork.com/ja/endpoint_incoming_requests.html#GET-incoming_requests
     # @see http://download.chatwork.com/ChatWork_API_Documentation.pdf
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [
@@ -36,7 +36,7 @@ module ChatWork
     #
     # @param request_id [Integer]
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {

--- a/lib/chatwork/me.rb
+++ b/lib/chatwork/me.rb
@@ -7,7 +7,7 @@ module ChatWork
     # @see http://developer.chatwork.com/ja/endpoint_me.html#GET-me
     # @see http://download.chatwork.com/ChatWork_API_Documentation.pdf
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {

--- a/lib/chatwork/member.rb
+++ b/lib/chatwork/member.rb
@@ -9,7 +9,7 @@ module ChatWork
     #
     # @param room_id [Integer]
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [
@@ -39,7 +39,7 @@ module ChatWork
     # @param members_member_ids [Array<Integer>, String] List of user IDs who will be given member permission for the group chat.
     # @param members_readonly_ids [Array<Integer>, String] List of user IDs who will be given read-only permission for the group chat.
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     # {

--- a/lib/chatwork/message.rb
+++ b/lib/chatwork/message.rb
@@ -12,7 +12,7 @@ module ChatWork
     # @param room_id [Integer]
     # @param force   [Boolean, Integer] Flag which forces to get 100 newest entries regardless of previous calls.
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [
@@ -40,7 +40,7 @@ module ChatWork
     # @param room_id [Integer]
     # @param body    [String] message body
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {
@@ -58,7 +58,7 @@ module ChatWork
     # @param room_id [Integer]
     # @param message_id [String]
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {
@@ -77,7 +77,7 @@ module ChatWork
     # @param room_id [Integer]
     # @param message_id [String]
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {
@@ -96,7 +96,7 @@ module ChatWork
     # @param room_id [Integer]
     # @param message_id [String]
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {
@@ -123,7 +123,7 @@ module ChatWork
     # @param message_id [String]
     # @param body [String] message body
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {
@@ -141,7 +141,7 @@ module ChatWork
     # @param room_id [Integer]
     # @param message_id [String]
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {

--- a/lib/chatwork/my_status.rb
+++ b/lib/chatwork/my_status.rb
@@ -7,7 +7,7 @@ module ChatWork
     # @see http://developer.chatwork.com/ja/endpoint_my.html#GET-my-status
     # @see http://download.chatwork.com/ChatWork_API_Documentation.pdf
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {

--- a/lib/chatwork/my_task.rb
+++ b/lib/chatwork/my_task.rb
@@ -12,7 +12,7 @@ module ChatWork
     # @param assigned_by_account_id [Integer] Account ID of the person who assigned task
     # @param status [String] Task status (open, done)
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [

--- a/lib/chatwork/room.rb
+++ b/lib/chatwork/room.rb
@@ -7,7 +7,7 @@ module ChatWork
     # @see http://developer.chatwork.com/ja/endpoint_rooms.html#GET-rooms
     # @see http://download.chatwork.com/ChatWork_API_Documentation.pdf
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [
@@ -47,7 +47,7 @@ module ChatWork
     # @param members_readonly_ids [Array<Integer>, String] List of user IDs who will be given read-only permission for the group chat.
     # @param name [String] Title of the group chat.
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {
@@ -75,7 +75,7 @@ module ChatWork
     #
     # @param room_id [Integer]
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {

--- a/lib/chatwork/task.rb
+++ b/lib/chatwork/task.rb
@@ -14,7 +14,7 @@ module ChatWork
     # @param assigned_by_account_id [Integer] Account ID of the person who assigned task
     # @param status [String] Task status (open, done)
     #
-    # @return [Array<Hash>]
+    # @return [Array<Hashie::Mash>]
     #
     # @example response format
     #   [
@@ -50,7 +50,7 @@ module ChatWork
     # @param to_ids [Array<Integer>, String] Account ID of the person/people responsible to complete the task
     # @param limit  [Time, Integer] When the task is due
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {
@@ -74,7 +74,7 @@ module ChatWork
     # @param room_id [Integer]
     # @param task_id [Integer]
     #
-    # @return [Hash]
+    # @return [Hashie::Mash]
     #
     # @example response format
     #   {

--- a/spec/lib/chatwork/chatwork_error_spec.rb
+++ b/spec/lib/chatwork/chatwork_error_spec.rb
@@ -6,9 +6,11 @@ describe ChatWork::ChatWorkError do
       let(:status) { 401 }
 
       let(:body) do
-        <<-JSON
-          {"errors":["Invalid API Token"]}
-        JSON
+        json =
+          <<-JSON
+            {"errors":["Invalid API Token"]}
+          JSON
+        Hashie::Mash.new(JSON.parse(json))
       end
 
       let(:headers) do

--- a/spec/lib/chatwork/me_spec.rb
+++ b/spec/lib/chatwork/me_spec.rb
@@ -8,6 +8,26 @@ describe ChatWork::Me do
 
     it_behaves_like :a_chatwork_api, :get, "/me"
 
+    its(:account_id)        { should eq 123 }
+    its(:room_id)           { should eq 322 }
+    its(:name)              { should eq "John Smith" }
+    its(:chatwork_id)       { should eq "tarochatworkid" }
+    its(:organization_id)   { should eq 101 }
+    its(:organization_name) { should eq "Hello Company" }
+    its(:department)        { should eq "Marketing" }
+    its(:title)             { should eq "CMO" }
+    its(:url)               { should eq "http://mycompany.example.com" }
+    its(:introduction)      { should eq "Self Introduction" }
+    its(:mail)              { should eq "taro@example.com" }
+    its(:tel_organization)  { should eq "XXX-XXXX-XXXX" }
+    its(:tel_extension)     { should eq "YYY-YYYY-YYYY" }
+    its(:tel_mobile)        { should eq "ZZZ-ZZZZ-ZZZZ" }
+    its(:skype)             { should eq "myskype_id" }
+    its(:facebook)          { should eq "myfacebook_id" }
+    its(:twitter)           { should eq "mytwitter_id" }
+    its(:avatar_image_url)  { should eq "https://example.com/abc.png" }
+    its(:login_mail)        { should eq "account@example.com" }
+
     context "when unauthorized" do
       before do
         stub_chatwork_request(:get, "/me", "/me", 401)

--- a/spec/support/matchers/match_example.rb
+++ b/spec/support/matchers/match_example.rb
@@ -3,6 +3,9 @@ RSpec::Matchers.define :match_example do |verb, resource, status = 200|
     expected_example = RamlParser.find_response_example(verb, resource, status)
     raise "Not found '#{verb.to_s.upcase} #{resource} #{status}' in '#{schema_file}'" unless expected_example
 
+    # NOTE: when empty response, FaradayMiddleware::ParseJson convert to nil
+    return true if status == 204 && actual.nil? && expected_example.empty?
+
     actual == expected_example
   end
 


### PR DESCRIPTION
# Before
```ruby
[1] pry(main)> response = ChatWork::Me.get

[2] pry(main)> response["name"]
=> "sue445"

[3] pry(main)> response[:name]
=> nil

[4] pry(main)> response.name
NoMethodError: undefined method `name' for #<Hash:0x00007fc7b39a69b0>
from (pry):4:in `<main>'
```

# After
```ruby
[1] pry(main)> response = ChatWork::Me.get

[2] pry(main)> response["name"]
=> "sue445"

[3] pry(main)> response[:name]
=> "sue445"

[4] pry(main)> response.name
=> "sue445"
```
