### PR TITLE
Reject spec/ from coveralls target

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,13 @@
 if ENV["CI"]
+  require "simplecov"
   require "coveralls"
-  Coveralls.wear!
+
+  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+  SimpleCov.start do
+    %w[spec].each do |ignore_path|
+      add_filter(ignore_path)
+    end
+  end
 end
 
 $LOAD_PATH << File.expand_path(File.join("..", "..", "lib"), __FILE__)


### PR DESCRIPTION
I want to reject `spec/` from following

![image](https://user-images.githubusercontent.com/608755/34945734-a776b236-fa47-11e7-9b49-491c9e9e4fea.png)


https://coveralls.io/github/asonas/chatwork-ruby
