### PR TITLE
Fixed. uninitialized constant ChatWork::AuthenticateError when other error class has not been called at all

### DIFF
--- a/lib/chatwork.rb
+++ b/lib/chatwork.rb
@@ -5,6 +5,7 @@ module ChatWork
   autoload :BaseClient,         "chatwork/base_client"
   autoload :APIConnectionError, "chatwork/chatwork_error"
   autoload :APIError,           "chatwork/chatwork_error"
+  autoload :AuthenticateError,  "chatwork/chatwork_error"
   autoload :ChatWorkError,      "chatwork/chatwork_error"
   autoload :Client,             "chatwork/client"
   autoload :Contacts,           "chatwork/contacts"


### PR DESCRIPTION
```
$ be irb -rchatwork
irb(main):001:0> ChatWork::AuthenticateError
=> ChatWork::AuthenticateError
irb(main):002:0>
```

Fixed #44