### PR TITLE
Remove pry

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -14,5 +14,5 @@ connection = @client.instance_variable_get(:@conn)
 connection.request :curl, logger, :debug
 connection.response :logger, logger, bodies: true
 
-require "pry"
-Pry.start
+require "irb"
+IRB.start

--- a/chatwork.gemspec
+++ b/chatwork.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "faraday_curl"
   spec.add_development_dependency "onkcop", "0.53.0.0"
-  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ require "chatwork"
 require "rspec-parameterized"
 require "rspec/its"
 require "webmock/rspec"
-require "pry"
 require "active_support/all"
 
 begin


### PR DESCRIPTION
Error in pry

```
An error occurred while loading spec_helper.
Failure/Error: require "pry"
NameError:
  uninitialized constant Pry::Command::ExitAll
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-byebug-3.7.0/lib/pry-byebug/commands/exit_all.rb:7:in `<module:PryByebug>'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-byebug-3.7.0/lib/pry-byebug/commands/exit_all.rb:3:in `<top (required)>'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-byebug-3.7.0/lib/pry-byebug/commands.rb:12:in `require'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-byebug-3.7.0/lib/pry-byebug/commands.rb:12:in `<top (required)>'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-byebug-3.7.0/lib/pry-byebug/cli.rb:5:in `require'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-byebug-3.7.0/lib/pry-byebug/cli.rb:5:in `<top (required)>'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-0.13.0/lib/pry/plugins.rb:55:in `require'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-0.13.0/lib/pry/plugins.rb:55:in `load_cli_options'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-0.13.0/lib/pry/cli.rb:40:in `each'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-0.13.0/lib/pry/cli.rb:40:in `add_plugin_options'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-0.13.0/lib/pry/cli.rb:134:in `<top (required)>'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-0.13.0/lib/pry.rb:78:in `require'
 ./gemfiles/vendor/bundle/ruby/2.3.0/gems/pry-0.13.0/lib/pry.rb:78:in `<top (required)>'
 ./spec/spec_helper.rb:20:in `require'
 ./spec/spec_helper.rb:20:in `<top (required)>'
No examples found.
```

https://travis-ci.org/github/asonas/chatwork-ruby/jobs/665134665