### PR TITLE
Fix NoMethodError: undefined method `mime_type=' for ChatWork::Multipart:Class with faraday-multipart v1.1.0+

### DIFF
--- a/chatwork.gemspec
+++ b/chatwork.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 2.0.0"
   spec.add_dependency "faraday-mashify"
-  spec.add_dependency "faraday-multipart"
+  spec.add_dependency "faraday-multipart", ">= 1.1.0"
 
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "bundler", ">= 1.3"

--- a/lib/chatwork/multipart.rb
+++ b/lib/chatwork/multipart.rb
@@ -1,7 +1,5 @@
 module ChatWork
   class Multipart < ::Faraday::Multipart::Middleware
-    self.mime_type = "multipart/form-data".freeze
-
     def create_multipart(env, params)
       original_body = super(env, params)
 


### PR DESCRIPTION
Close #89